### PR TITLE
CI tests and tests with specific Django version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 
 root = true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
   - 3.3
@@ -15,12 +16,10 @@ matrix:
     # Python/Django combinations that aren't officially supported
     - { python: 3.3, env: DJANGO=2.1 }
     - { python: 3.4, env: DJANGO=2.1 }
-
-python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  include:
+    # Work around Travis Python 3.7 issue: https://github.com/travis-ci/travis-ci/issues/9815
+    - { python: 3.7, env: DJANGO=2.0, dist: xenial, sudo: true }
+    - { python: 3.7, env: DJANGO=2.1, dist: xenial, sudo: true }
 
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install:
+  - python setup.py -q install
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 cache: pip
 
 python:
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -14,7 +13,6 @@ env:
 matrix:
   exclude:
     # Python/Django combinations that aren't officially supported
-    - { python: 3.3, env: DJANGO=2.1 }
     - { python: 3.4, env: DJANGO=2.1 }
   include:
     # Work around Travis Python 3.7 issue: https://github.com/travis-ci/travis-ci/issues/9815

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 
 install:
   - python setup.py -q install
+  - pip install tox
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
 language: python
 
 python:
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+
+env:
+  - DJANGO=2.0
+  - DJANGO=2.1
+
+matrix:
+  exclude:
+    # Python/Django combinations that aren't officially supported
+    - { python: 3.3, env: DJANGO=2.1 }
+    - { python: 3.4, env: DJANGO=2.1 }
+
+python:
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 
 install:
-  - python setup.py -q install
-  - pip install tox
+  - pip install tox-travis
 
 script:
   - tox

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Django app provides Django-specific functionality on top of the [Nexmo Clie
 
 ## How To Install It
 
-Currently, `dj-nexmo` **only** supports Python 3.3+, and Django 2.0+. We _may_ backport to Django 1.x, but we have no intention of backporting to Python 2.
+Currently, `dj-nexmo` **only** supports Python 3.4+, and Django 2.0+. We _may_ backport to Django 1.x, but we have no intention of backporting to Python 2.
 
 First, `pip install dj-nexmo`
 
@@ -54,7 +54,7 @@ your private key.
 
 ## Using the Nexmo Client
 
-`dj-nexmo` configures a Nexmo `Client` object from the settings above. You can 
+`dj-nexmo` configures a Nexmo `Client` object from the settings above. You can
 use it by importing it from the `djnexmo` package:
 
 ```python
@@ -80,10 +80,10 @@ available.
 def sms_registration(request):
     # Your parsed & merged SMS message will be available as `request.sms`:
     sms = request.sms
-    
-    # Don't do any long processing here - you should return a 200 response as soon as possible. 
+
+    # Don't do any long processing here - you should return a 200 response as soon as possible.
     ...
-    
+
     return HttpResponse("OK")
 ```
 
@@ -108,7 +108,7 @@ Local Format: {{ "447700900486" | national }}       => 07700 900486
 
 ## License
 
-This code is open-source, released under the Apache License. This means it is free to use 
+This code is open-source, released under the Apache License. This means it is free to use
 for commercial or non-commercial purposes, and you can make any changes you would like or need.
 
 
@@ -122,6 +122,6 @@ demonstrates the problem you've seen would be very useful and means we should be
 your problem sooner!
 
 
-[Nexmo API]: https://developer.nexmo.com/ 
-[phonenumbers]: https://github.com/google/phonenumbers 
+[Nexmo API]: https://developer.nexmo.com/
+[phonenumbers]: https://github.com/google/phonenumbers
 [Nexmo Client Library for Python]: https://github.com/nexmo/nexmo-python

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "nexmo          >= 2.0.0,<2.1",
         "django         >= 2.0.0",
         "attrs          ~= 17.4.0",
-        "marshmallow    ~= 3.0.0b11",
+        "marshmallow    == 3.0.0b11",
         "phonenumbers   ~= 8.9.4",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
         "console_scripts": ["dj = django.core.management:execute_from_command_line"]
     },
     install_requires=[
-        "nexmo          >= 2.0.0,<3.0",
+        "nexmo          >= 2.0.0,<2.1",
         "django         >= 2.0.0",
         "attrs          ~= 17.4.0",
-        "marshmallow    ~= 3.0.0b8",
+        "marshmallow    ~= 3.0.0b11",
         "phonenumbers   ~= 8.9.4",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     clean
     # Python/Django combinations that are officially supported
-    py{33,34,35,36,37}-django20
+    py{34,35,36,37}-django20
     py{35,36,37}-django21
     coverage
 
@@ -18,7 +18,6 @@ deps =
     setuptools>=18.5
     pip>=10.0.1
     py{34,35,36,37}: pytest
-    py33: pytest<3.3.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     clean
     # Python/Django combinations that are officially supported
-    py{33,34,35,36}-django20
-    py{35,36}-django21
+    py{33,34,35,36,37}-django20
+    py{35,36,37}-django21
     coverage
 
 [testenv:clean]
@@ -17,7 +17,7 @@ commands =
 deps =
     setuptools>=18.5
     pip>=10.0.1
-    py{27,34,35,36}: pytest
+    py{34,35,36,37}: pytest
     py33: pytest<3.3.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = clean,py33,py34,py35,py36,coverage
+envlist =
+    clean
+    py33-django20
+    py34-django20
+    py35-django20
+    py35-django21
+    py36-django20
+    py36-django21
+    coverage
 
 [testenv:clean]
 skip_install=True
@@ -15,6 +23,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
+    django20: Django>=2.0, <2.1
+    django21: Django>=2.1, <2.2
 setenv =
     PYTHONPATH = {toxinidir}
     COVERAGE_FILE=.coverage.{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ commands =
 deps =
     setuptools>=18.5
     pip>=10.0.1
-    py{34,35,36,37}: pytest
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    pytest
     pytest-cov
     pytest-django
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
 envlist =
     clean
-    py33-django20
-    py34-django20
-    py35-django20
-    py35-django21
-    py36-django20
-    py36-django21
+    # Python/Django combinations that are officially supported
+    py{33,34,35,36}-django20
+    py{35,36}-django21
     coverage
 
 [testenv:clean]
@@ -20,15 +17,16 @@ commands =
 deps =
     setuptools>=18.5
     pip>=10.0.1
-    pytest
+    py{27,34,35,36}: pytest
+    py33: pytest<3.3.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     pytest-cov
     pytest-django
-    django20: Django>=2.0, <2.1
-    django21: Django>=2.1, <2.2
 setenv =
     PYTHONPATH = {toxinidir}
     COVERAGE_FILE=.coverage.{envname}
-commands = 
+commands =
     pytest --cov=djnexmo {posargs}
 
 [testenv:coverage]
@@ -40,3 +38,8 @@ commands =
     coverage combine
     coverage html
     coverage report
+
+[travis:env]
+DJANGO =
+    2.0: django20
+    2.1: django21


### PR DESCRIPTION
- added `.travis.yml` config file (maintainer still needs to turn the switch on in Travis CIs interface)
  - passed builds can be seen here: https://travis-ci.org/mislavcimpersak/dj-nexmo
- dropped Python 3.3 since in 2017 it [reached end-of-life](https://www.python.org/dev/peps/pep-0398/#lifespan)
  - also, finding just the right packages that work with py3.3 can be a daunting task
- using Travis matrix to test different combos of Python and Django
- added testing for Python 3.7 support
- fixed marshmallow version because newer marshmallow is throwing errors (using a newer package should be fixed in another PR)
- ~fixed nexmo version because newer nexmo is throwing errors (using a newer package should be fixed in another PR)