### PR TITLE
Specify full path to README and open it with utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup, find_packages
 
 
@@ -9,7 +11,8 @@ setup(
     url="https://developer.nexmo.com/",
     description="Utilities for Django developers using Nexmo's APIs",
 
-    long_description=open("README.md").read(),
+    long_description=open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"),
+                          encoding="utf-8").read(),
     long_description_content_type="text/markdown",
 
     packages=find_packages("src"),


### PR DESCRIPTION
This fix prevents the crash during the installation on machines with non-standard locales:
https://github.com/RGF-team/rgf/issues/65
https://github.com/henry0312/pytest-codestyle/pull/34