### PR TITLE
Adds python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "marshmallow    ~= 3.0.0b8",
         "phonenumbers   ~= 8.9.4",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.4",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Django :: 2.0",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "marshmallow    ~= 3.0.0b8",
         "phonenumbers   ~= 8.9.4",
     ],
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Django :: 2.0",


### PR DESCRIPTION
Adds `python_requires` in `setup.py` to avoid installing `dj-nexmo` on python versions that are not supported.